### PR TITLE
Avoid double encoding on update and create

### DIFF
--- a/frontends/default/views/on_create.js.erb
+++ b/frontends/default/views/on_create.js.erb
@@ -9,7 +9,7 @@ unless nested_singular_association?
     reorder_params = {}
     reorder_params[:eid] = params[:eid] unless params[:eid].blank?
 %>
-    <%= "ActiveScaffold.sortable('#{sort_params[0]}', '#{controller_name}', #{reorder_params.to_json});" %>
+    <%= "ActiveScaffold.sortable('#{sort_params[0]}', #{controller_name.to_json}, #{reorder_params.to_json});".html_safe %>
 <%
   end if controller.send :successful?
 end

--- a/frontends/default/views/on_update.js.erb
+++ b/frontends/default/views/on_update.js.erb
@@ -10,7 +10,7 @@ unless nested_singular_association?
     reorder_params = {}
     reorder_params[:eid] = params[:eid] unless params[:eid].blank?
 %>
-    <%= "ActiveScaffold.sortable('#{sort_params[0]}', #{controller_name.to_json}, #{reorder_params.to_json});" %>
+    <%= "ActiveScaffold.sortable('#{sort_params[0]}', #{controller_name.to_json}, #{reorder_params.to_json});".html_safe %>
 <%
   end if controller.send :successful?
 end


### PR DESCRIPTION
Inserted a html_safe statement in the update and create view in order to avoid the double encoding of the JS parameters.
