### PR TITLE
Items must be direct child tags

### DIFF
--- a/app/assets/javascripts/jquery/active_scaffold_sortable.js
+++ b/app/assets/javascripts/jquery/active_scaffold_sortable.js
@@ -50,7 +50,7 @@ ActiveScaffold.sortable = function(element) {
     }
   }
   sortable_options.handle = element.data('handle');
-  sortable_options.items = element.data('tag');
+  sortable_options.items = '> ' + element.data('tag');
   content.sortable(sortable_options);
 };
 


### PR DESCRIPTION
For the jQuery version of the sortable Javascript, any descendant tr tag is an item, however it should only be direct child tags. This issue can be seen when the entire row is selectable, and the user mouses down in the actions column. Since the actions are inside their own table, the row they are in is an item and is allowed to be moved, which allows them to be moved into the parent list table.

This change prepends the child selector to the tag.